### PR TITLE
Ativa o cache como default para todos os repositórios que utilizarem o trybe-image-builder

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,7 @@ inputs:
   enableCache:
     description: "Flag para utilizar a funcionalidade de cache do docker"
     required: false
+    default: "Y"
   githubToken:
     description: "Github Token para logar no ghcr.io caso o cache esteja ativo"
     required: false


### PR DESCRIPTION
Esse é o PR que bota fogo em tudo :D