### PR TITLE
feat: testa criação de contexto para o self-hosted

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,13 +46,15 @@ else
 
     echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
+    docker context create tls-environment
+
     docker buildx create \
       --name cache-builder \
       --driver docker-container \
       --buildkitd-flags '\
       --allow-insecure-entitlement security.insecure \
       --allow-insecure-entitlement network.host' \
-      --use
+      --use tls-environment
 
     echo "Cache ativado"
   else


### PR DESCRIPTION
Ao testar os runners self-hosted, sem essa modificação, o seguinte erro estava acontecendo:
```
error: could not create a builder instance with TLS data loaded from environment. Please use `docker context create <context-name>` to create a context for current environment and then create a builder instance with `docker buildx create <context-name>`
```
Exemplo: https://github.com/betrybe/preview-app-manager/runs/4069702398?check_suite_focus=true

Após esta alteração, o fluxo funciona corretamente em ambos ambientes de execução:

Self-hosted Runner: https://github.com/betrybe/preview-app-manager/runs/4070261997?check_suite_focus=true
Hosted Runner: https://github.com/betrybe/preview-app-manager/runs/4070362813?check_suite_focus=true